### PR TITLE
Add data loader and config schema with tests

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,10 +1,10 @@
 data:
-    excel_path: "/data/Case Study - Data & AI Engineer.xlsx"
-        sheets:
-            - "1.1 RX 目标市场"
-            - "1.2 电子商务 目标市场"
-            - "1.3 Device"
-            - "1.4 Retail"
-            - "1.5 CSO&DSO 广阔市场"
-            - "1.6 非目标市场"
-            - "4 产品 DIM"
+    excel_path: "data/Case Study - Data & AI Engineer.xlsx"
+    sheets:
+        - "1.1 RX 目标市场"
+        - "1.2 电子商务 目标市场"
+        - "1.3 Device"
+        - "1.4 Retail"
+        - "1.5 CSO&DSO 广阔市场"
+        - "1.6 非目标市场"
+        - "4 产品 DIM"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "hydra-core>=1.3.2",
     "omegaconf>=2.3.0",
+    "pandas>=2.2.2",
+    "openpyxl>=3.1.2",
+    "pydantic>=2.6.4",
 ]

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -5,8 +5,8 @@ from typing import Dict, Optional
 
 import yaml
 
-from .config_models import ConfigSchema
-from .logging import get_logger
+from config_models import ConfigSchema
+from log_utils import get_logger
 
 class ConfigLoader:
     """Load and validate project configuration."""
@@ -24,7 +24,8 @@ class ConfigLoader:
         if config_path:
             with open(config_path, "r", encoding="utf-8") as f:
                 config_dict = yaml.safe_load(f)
-            self.base_dir = os.path.dirname(os.path.abspath(config_path))
+            # Treat the project root (parent of the config directory) as base
+            self.base_dir = os.path.dirname(os.path.dirname(os.path.abspath(config_path)))
         elif config:
             config_dict = config
             self.base_dir = os.getcwd()

--- a/src/config_models.py
+++ b/src/config_models.py
@@ -1,4 +1,19 @@
 from __future__ import annotations
-from typing import List, Dict, Optional, Any
-from pydantic import BaseModel, ConfigDict, field_validator
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class DataConfig(BaseModel):
+    """Configuration for dataset loading."""
+
+    excel_path: str = Field(..., description="Path to the Excel workbook")
+    sheets: List[str] = Field(..., description="List of sheet names to load")
+
+
+class ConfigSchema(BaseModel):
+    """Root configuration schema."""
+
+    data: DataConfig
 

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,4 +1,31 @@
+"""Utilities for loading datasets from Excel workbooks."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+
 class DataLoader:
-    """
-    Load Excel datasets
-    """
+    """Load multiple sheets from an Excel workbook."""
+
+    def __init__(self, excel_path: str, sheets: list[str]) -> None:
+        self.excel_path = excel_path
+        self.sheets = sheets
+
+    def load(self) -> Dict[str, pd.DataFrame]:
+        """Load all configured sheets.
+
+        Returns
+        -------
+        Dict[str, pd.DataFrame]
+            Mapping of sheet name to loaded :class:`~pandas.DataFrame`.
+        """
+
+        data = pd.read_excel(self.excel_path, sheet_name=self.sheets)
+        # `pandas.read_excel` returns a DataFrame when a single sheet is passed,
+        # but a dict when a list is provided. Ensure we always return a dict.
+        if isinstance(data, pd.DataFrame):
+            return {self.sheets[0]: data}
+        return data

--- a/src/log_utils.py
+++ b/src/log_utils.py
@@ -1,0 +1,16 @@
+"""Simple logging utilities for tests."""
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a configured logger."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,13 +1,31 @@
-import pandas as pd
-from hydra import compose, initialize_config_dir
-from omegaconf import OmegaConf
 import os
+import pandas as pd
+
+from config_loader import ConfigLoader
+from data_loader import DataLoader
+
 
 def get_loader():
-    "Instantiates Dataloader using hydra config"
-    pass
+    """Instantiate DataLoader using the project configuration."""
+    repo_dir = os.path.dirname(os.path.dirname(__file__))
+    config_path = os.path.join(repo_dir, "conf", "config.yaml")
+    loader = ConfigLoader(config_path=config_path)
+    cfg = loader.get_config()
+    excel_path = loader.resolve_path(cfg.data.excel_path)
+    return DataLoader(excel_path, cfg.data.sheets), cfg
+
 
 def test_load_configured_sheets():
-    """Dataloader should load all specified sheets in the config"""
-    pass
+    dataloader, cfg = get_loader()
+    loaded = dataloader.load()
+
+    # Verify that all configured sheets are loaded
+    assert set(loaded.keys()) == set(cfg.data.sheets)
+
+    # Validate each sheet's shape matches a fresh read
+    with pd.ExcelFile(dataloader.excel_path) as xl:
+        for sheet in cfg.data.sheets:
+            df_expected = pd.read_excel(xl, sheet_name=sheet)
+            df_loaded = loaded[sheet]
+            assert df_loaded.shape == df_expected.shape
 


### PR DESCRIPTION
## Summary
- fix config file formatting
- add pydantic-based config models
- implement configuration loader and Excel data loader
- provide simple logging utility
- create pytest checking sheet loading and shapes
- update dependencies

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c6768c4248333b9072679cf94a499